### PR TITLE
fix: restructure shell startup for cross-platform PATH handling

### DIFF
--- a/.bash_profile
+++ b/.bash_profile
@@ -1,24 +1,15 @@
 # .bash_profile
+# Login shell startup — sources .bashrc for environment and interactive config.
+# On macOS this is the primary shell startup file; on Linux .profile usually
+# handles this, but .bash_profile takes precedence when it exists.
 
-# Get the aliases and functions
+# Source .bashrc (environment + interactive config)
 if [ -f ~/.bashrc ]; then
 	. ~/.bashrc
 fi
 
-# User specific environment and startup programs
-
-PATH=$PATH:$HOME/.local/bin:$HOME/bin
-
-export PATH
-#export PATH="/usr/local/opt/qt/bin:$PATH"
-#export PATH="/usr/local/Cellar/qt/5.12.2/bin:$PATH"
-#export XKB_DEFAULT_LAYOUT="us,us"
-#export XKB_DEFAULT_OPTIONS="caps:none"
-export DESKTOP="KDE"
-
-#test -e "${HOME}/.iterm2_shell_integration.bash" && source "${HOME}/.iterm2_shell_integration.bash"
-export PATH=/opt/homebrew/bin:/Users/neon/.config/bin:/Users/neon/.nix-profile/bin:/run/current-system/sw/bin:/nix/var/nix/profiles/default/bin:/usr/local/bin:/usr/bin:/usr/sbin:/bin:/sbin:/Users/neon/.local/bin:/Users/neon/bin
-
-# Added by OrbStack: command-line tools and integration
-# This won't be added again if you remove it.
-source ~/.orbstack/shell/init.bash 2>/dev/null || :
+# Platform-specific login additions
+if [[ "$OSTYPE" == "darwin"* ]]; then
+	# macOS: OrbStack CLI integration
+	source ~/.orbstack/shell/init.bash 2>/dev/null || :
+fi

--- a/.bashrc
+++ b/.bashrc
@@ -2,9 +2,6 @@
 # ~/.bashrc
 #
 
-# If not running interactively, don't do anything
-[[ $- != *i* ]] && return
-
 # === Platform Detection ===
 # Sets __platform to one of: macos, nixos, ubuntu, linux, unknown
 # Reference this variable for any platform-specific logic below.
@@ -20,6 +17,26 @@ else
 	__platform="unknown"
 fi
 
+# === Environment (applies to all shells, including non-interactive) ===
+export EDITOR=nvim
+export PATH="$HOME/.config/bin:$PATH"
+
+# === Local Secrets ===
+# API keys, tokens, etc. — not committed to dotfiles
+if [ -f ~/.config/secrets.env ]; then
+	. ~/.config/secrets.env
+fi
+
+# === Local Overrides (early) ===
+# Machine-specific PATH and env — sourced before the interactive guard
+# so non-interactive shells (e.g., Pi agent) get them too.
+if [ -f ~/.bashrc.local ]; then
+	. ~/.bashrc.local
+fi
+
+# If not running interactively, don't do anything past this point
+[[ $- != *i* ]] && return
+
 # === History ===
 HISTCONTROL=ignoreboth
 HISTSIZE=1000
@@ -29,10 +46,8 @@ shopt -s histappend
 # === Shell Options ===
 shopt -s checkwinsize
 
-# === Environment ===
+# === Prompt ===
 PS1="\[\e[00;37m\]\\$ \[\e[0m\]\[\e[00;31m\]\w\[\e[0m\]\[\e[00;37m\] \[\e[0m\]\[\e[00;36m\]\u@\h\[\e[0m\]\[\e[00;37m\] > \[\e[0m\]"
-export EDITOR=nvim
-export PATH="$HOME/.config/bin:$PATH"
 
 # === Theming ===
 if [[ "$__platform" != "macos" ]]; then
@@ -83,14 +98,4 @@ if [ -d "$GNUPGHOME" ] && ! grep -q "^pinentry-program" "$GNUPGHOME/gpg-agent.co
 	gpg-connect-agent reloadagent /bye 2>/dev/null
 fi
 
-# === Local Secrets ===
-# API keys, tokens, etc. — not committed to dotfiles
-if [ -f ~/.config/secrets.env ]; then
-	. ~/.config/secrets.env
-fi
 
-# === Local Overrides ===
-# Machine-specific config that doesn't belong in dotfiles
-if [ -f ~/.bashrc.local ]; then
-	. ~/.bashrc.local
-fi


### PR DESCRIPTION
## Problem

The `.bash_profile` from macOS dotfiles was hardcoding `export PATH=/opt/homebrew/bin:/Users/neon/...` which overwrote all PATH additions from `.bashrc` and `.bashrc.local` on the Parallels VM. This broke tool discovery for agent-browser, cargo, bun, and anything else installed to user-local paths.

Additionally, environment setup (PATH, secrets, local overrides) was below the interactive guard in `.bashrc`, so non-interactive shells (e.g. Pi agent's bash tool) never received them.

## Changes

- **`.bash_profile`**: Replace macOS-specific hardcoded PATH with a platform-aware version that just sources `.bashrc`
- **`.bashrc`**: Move env, PATH, secrets, and `.bashrc.local` sourcing above the interactive guard. Aliases, prompt, completion, etc. remain below it.

## Testing

- New login shell: `pi` resolves to 0.58.3 at `~/.local/share/npm/bin/pi`
- `agent-browser`, `cargo`, `bun` all on PATH
- Aliases (`cp` → rsync, etc.) do NOT leak into non-interactive shells
- GPG signing works