### PR TITLE
fix: handle ENOENT when session memory file already renamed

### DIFF
--- a/.pi/agent/extensions/stateful-memory/extension.js
+++ b/.pi/agent/extensions/stateful-memory/extension.js
@@ -533,7 +533,15 @@ export default function (pi) {
       }
     }
 
-    await fs.rename(oldPath, newPath);
+    try {
+      await fs.rename(oldPath, newPath);
+    } catch (err) {
+      if (err.code === "ENOENT") {
+        // Source file already renamed or never created — nothing to move.
+        return;
+      }
+      throw err;
+    }
     store.setMemoryFile(newName);
     topicLocked = true;
     pi.appendEntry(STATE_ENTRY, { memoryFile: newName, topicLocked: true });


### PR DESCRIPTION
The `maybeSetTopicFromSummary` rename crashes with ENOENT if the source `__untitled.md` file was already renamed by a prior summarization pass (e.g. during a fork or session switch) but the in-memory state fell out of sync.

Wraps `fs.rename` in a try/catch that silently skips when the source file doesn't exist.