### PR TITLE
stateful-memory: add baseDir config, fix path resolution against cwd

### DIFF
--- a/.pi/agent/extensions/stateful-memory/config.js
+++ b/.pi/agent/extensions/stateful-memory/config.js
@@ -2,7 +2,10 @@ import { promises as fs } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
+const DEFAULT_BASE_DIR = path.join(os.homedir(), ".pi");
+
 const DEFAULT_CONFIG = {
+  baseDir: DEFAULT_BASE_DIR,
   memoryDir: "stateful-memory/memory/sessions",
   personaFile: "stateful-memory/SOUL.md",
   auxiliaryPersonaFiles: [
@@ -54,39 +57,21 @@ function resolveRelative(value, baseDir) {
   return path.isAbsolute(value) ? value : path.resolve(baseDir, value);
 }
 
-function resolveConfigPaths({ config, envConfig, fileConfig, globalConfig, cwd }) {
-  const globalBaseDir = path.dirname(GLOBAL_CONFIG_PATH);
-  const localBaseDir = cwd;
+function resolveConfigPaths({ config }) {
+  // Resolve baseDir first — everything else is relative to it.
+  const baseDir = config.baseDir
+    ? (path.isAbsolute(config.baseDir) ? config.baseDir : path.resolve(config.baseDir))
+    : DEFAULT_BASE_DIR;
 
-  const resolved = { ...config };
-
-  const pickBase = (key) => {
-    if (envConfig[key] !== undefined) return localBaseDir;
-    if (Object.prototype.hasOwnProperty.call(fileConfig, key)) return localBaseDir;
-    if (Object.prototype.hasOwnProperty.call(globalConfig, key)) return globalBaseDir;
-    return localBaseDir;
-  };
+  const resolved = { ...config, baseDir };
 
   for (const key of PATH_KEYS) {
-    const baseDir = pickBase(key);
     resolved[key] = resolveRelative(resolved[key], baseDir);
   }
 
   for (const key of PATH_ARRAY_KEYS) {
-    const baseDir = pickBase(key);
     const entries = Array.isArray(resolved[key]) ? resolved[key] : [];
     resolved[key] = entries.map((entry) => resolveRelative(entry, baseDir));
-  }
-
-  if (resolved.personaFile && resolved.topicsFile && !path.isAbsolute(resolved.topicsFile)) {
-    resolved.topicsFile = path.resolve(path.dirname(resolved.personaFile), resolved.topicsFile);
-  }
-
-  if (resolved.personaFile && Array.isArray(resolved.auxiliaryPersonaFiles)) {
-    resolved.auxiliaryPersonaFiles = resolved.auxiliaryPersonaFiles.map((entry) => {
-      if (!entry || path.isAbsolute(entry)) return entry;
-      return path.resolve(path.dirname(resolved.personaFile), entry);
-    });
   }
 
   return resolved;
@@ -140,13 +125,7 @@ export async function loadConfig(cwd) {
     ),
   };
 
-  return resolveConfigPaths({
-    config: merged,
-    envConfig,
-    fileConfig,
-    globalConfig,
-    cwd,
-  });
+  return resolveConfigPaths({ config: merged });
 }
 
 export function resolvePath(cwd, targetPath) {

--- a/.pi/agent/extensions/stateful-memory/extension.js
+++ b/.pi/agent/extensions/stateful-memory/extension.js
@@ -3,7 +3,7 @@ import path from "node:path";
 import { Type } from "@sinclair/typebox";
 import { StringEnum } from "@mariozechner/pi-ai";
 
-import { loadConfig, resolvePath } from "./config.js";
+import { loadConfig } from "./config.js";
 import { MemoryStore, slugifyKeywords, slugifyTopic } from "./memory-store.js";
 import { buildTranscriptFromEntries, extractText, readSessionJsonl } from "./session-utils.js";
 import { runSleepCycle } from "./memory-sleep.js";
@@ -54,15 +54,12 @@ export default function (pi) {
     }
 
     if (!store) {
-      const memoryDir = resolvePath(cwd, config.memoryDir);
       store = new MemoryStore({
-        memoryDir,
-        personaFile: resolvePath(cwd, config.personaFile),
-        auxiliaryPersonaFiles: (config.auxiliaryPersonaFiles ?? []).map((f) =>
-          resolvePath(cwd, f)
-        ),
-        factsFile: resolvePath(cwd, config.factsFile),
-        wakeFile: resolvePath(cwd, config.wakeFile),
+        memoryDir: config.memoryDir,
+        personaFile: config.personaFile,
+        auxiliaryPersonaFiles: config.auxiliaryPersonaFiles ?? [],
+        factsFile: config.factsFile,
+        wakeFile: config.wakeFile,
       });
     }
   }


### PR DESCRIPTION
- Add `baseDir` config key (default: `~/.pi/`) as single source for all relative path resolution
- Replace `pickBase()` which fell through to `cwd` for default config keys, causing FACTS.md and other files to resolve against pwd
- Remove redundant `resolvePath(cwd, ...)` double-resolution in `loadStore()`
- Convert `stateful-memory.json` to relative paths under `baseDir`