### PR TITLE
Migrate extensions to pi 0.67.2 APIs

### DIFF
--- a/.pi/agent/extensions/delegate/fork-runner.ts
+++ b/.pi/agent/extensions/delegate/fork-runner.ts
@@ -245,7 +245,7 @@ function extractSummary(fullText: string, lastTurnText: string): string {
 async function createForkSession(cwd: string) {
   const authStorage = AuthStorage.create(join(AGENT_DIR, "auth.json"));
   const modelsPath = join(AGENT_DIR, "models.json");
-  const modelRegistry = new ModelRegistry(
+  const modelRegistry = ModelRegistry.create(
     authStorage,
     existsSync(modelsPath) ? modelsPath : undefined
   );

--- a/.pi/agent/extensions/force-tools.ts
+++ b/.pi/agent/extensions/force-tools.ts
@@ -44,11 +44,9 @@ export default function forceTools(pi: ExtensionAPI) {
     pi.setActiveTools(tools);
   };
 
+  // session_start fires for startup/reload/new/resume/fork (pi 0.65.0+),
+  // so a single handler covers what used to be session_start + session_switch.
   pi.on("session_start", async () => {
-    enable();
-  });
-
-  pi.on("session_switch", async () => {
     enable();
   });
 }

--- a/.pi/agent/extensions/stateful-memory/extension.js
+++ b/.pi/agent/extensions/stateful-memory/extension.js
@@ -613,20 +613,19 @@ export default function (pi) {
     });
   }
 
-  pi.on("session_start", async (_event, ctx) => {
-    await ensureSessionState(ctx);
-    if (ctx.hasUI) {
-      ctx.ui.setStatus("stateful-memory", "Memory: ready");
+  // pi 0.65.0+ unified session_start + session_switch into a single event
+  // that fires for all session transitions (startup/reload/new/resume/fork).
+  // Reset per-session caches on any non-startup transition so we don't carry
+  // state from the outgoing session.
+  pi.on("session_start", async (event, ctx) => {
+    if (event.reason && event.reason !== "startup") {
+      sessionInitialized = false;
+      lastSessionPath = null;
+      pendingResumeSessionPath = null;
+      pendingSessionInit = false;
+      topicLocked = false;
+      activeTopics = new Map();
     }
-  });
-
-  pi.on("session_switch", async (_event, ctx) => {
-    sessionInitialized = false;
-    lastSessionPath = null;
-    pendingResumeSessionPath = null;
-    pendingSessionInit = false;
-    topicLocked = false;
-    activeTopics = new Map();
     await ensureSessionState(ctx);
     if (ctx.hasUI) {
       ctx.ui.setStatus("stateful-memory", "Memory: ready");

--- a/.pi/agent/extensions/stateful-memory/memory-sleep.js
+++ b/.pi/agent/extensions/stateful-memory/memory-sleep.js
@@ -105,7 +105,7 @@ function loadSharedInfra(cwd) {
 
   const authStorage = AuthStorage.create(join(AGENT_DIR, "auth.json"));
   const modelsPath = join(AGENT_DIR, "models.json");
-  const modelRegistry = new ModelRegistry(
+  const modelRegistry = ModelRegistry.create(
     authStorage,
     existsSync(modelsPath) ? modelsPath : undefined
   );

--- a/.pi/agent/extensions/tools.ts
+++ b/.pi/agent/extensions/tools.ts
@@ -139,8 +139,11 @@ export default function toolsExtension(pi: ExtensionAPI) {
 		restoreFromBranch(ctx);
 	});
 
-	// Restore state after forking
-	pi.on("session_fork", async (_event, ctx) => {
-		restoreFromBranch(ctx);
+	// Restore state after forking. pi 0.65.0+ folded session_fork into
+	// session_start with event.reason === "fork".
+	pi.on("session_start", async (event, ctx) => {
+		if (event.reason === "fork") {
+			restoreFromBranch(ctx);
+		}
 	});
 }

--- a/.pi/agent/extensions/web-search.ts
+++ b/.pi/agent/extensions/web-search.ts
@@ -105,11 +105,9 @@ export default function webSearch(pi: ExtensionAPI) {
     }
   }
 
+  // session_start fires for startup/reload/new/resume/fork (pi 0.65.0+),
+  // so a single handler covers what used to be session_start + session_switch.
   pi.on("session_start", async (_event, ctx) => {
-    restore(ctx);
-  });
-
-  pi.on("session_switch", async (_event, ctx) => {
     restore(ctx);
   });
 


### PR DESCRIPTION
Upgrades pi from 0.64.0 to 0.67.2 and migrates extensions to the new APIs.

## Breaking changes addressed

**pi 0.65.0** folded `session_switch` and `session_fork` events into a unified `session_start` with `event.reason` (`"startup" | "reload" | "new" | "resume" | "fork"`).
**pi 0.64.0** made the `ModelRegistry` constructor private; `ModelRegistry.create()` is the documented path.

## Changes

- `web-search.ts`, `force-tools.ts`: drop duplicate `session_switch` handlers (identical to existing `session_start`).
- `tools.ts`: replace `session_fork` with `session_start` filtered on `event.reason === "fork"`.
- `stateful-memory/extension.js`: merge `session_switch` cleanup into `session_start`, gated on `event.reason !== "startup"`.
- `delegate/fork-runner.ts`, `stateful-memory/memory-sleep.js`: switch `new ModelRegistry(...)` → `ModelRegistry.create(...)`. Runtime still accepted the old form (JS doesn't enforce TS `private`), but the public API is more correct.

## Nothing in 0.65–0.67 is concerning

New features surveyed but not adopted in this PR: `defineTool()` helper (0.65.0), `PI_CODING_AGENT=true` env var (0.67.1), multiple `--append-system-prompt` flags (0.67.2). Worth considering later but not needed for compat.